### PR TITLE
Amends to be more pythonic(ish):

### DIFF
--- a/ntptime.py
+++ b/ntptime.py
@@ -1,20 +1,25 @@
 """retrieves time from ntpserver and displays it on oled screen"""
 
 import time
-import ntptime
+import ntptime  # this file name is same as this module - need to change
 import machine
 import ssd1306
+
+LASTUPDATE = None
+UPDATEINTERVAL = None
+
 
 i2c = machine.I2C(scl=machine.Pin(5), sda=machine.Pin(4))
 oled = ssd1306.SSD1306_I2C(64, 48, i2c) # width, height, pins
 
-def setTime():
-    global LASTUPDATE
+def set_time():
+    """set time function"""
+    global LASTUPDATE       # these globals need to be difine at global level
     global UPDATEINTERVAL
     LASTUPDATE = time.time()
     try:
         ntptime.settime()
-        UPDATEINTERVAL = 300 #5mins
+        UPDATEINTERVAL = 300 #5mins - MAGIC NUMBER!
         print('succesfully synced time from ntp server: ' + ntptime.host)
         print('next update in ' + str(UPDATEINTERVAL) + ' seconds')
         # return True
@@ -24,40 +29,42 @@ def setTime():
         print('trying again in ' + str(UPDATEINTERVAL) + ' seconds')
         # return False
 
-def checkUpdate(last, interv):
+def check_update(last, interv):
+    """check updeate function"""
     if time.time() - (interv) > last:
-        return True
-    else:
-        return False
+        return True     # else: not required
+    return False
 
 def pad(p):
-    if p < 10:
-        return '0' + str(p)
-    else:
-        return str(p)
+    """pad function"""
+    if p < 10:  # MAGIC NUMBER!
+        return '0' + str(p)     # else: not required
+    return str(p)
 
-def printTime(h, m, s):
+def print_time(h, m, s):
+    """print time function"""
     print(time.localtime())
     oled.fill(0) # clear the screen
     oled.text(pad(h + 1) + ':' + pad(m) + ':' + pad(s), 0, 0) #hack for BST!!
     oled.show()
 
-def printBinTime(h, m, s):
+def print_bin_time(h, m, s):
+    """print bin time function"""
     print(time.localtime())
     oled.fill(0) # clear the screen
     oled.text("{0:08b}".format(h + 1), 0, 0) #hack for BST!!
     oled.text("{0:08b}".format(m), 0, 10)
-    oled.text("{0:08b}".format(s), 0, 20) 
+    oled.text("{0:08b}".format(s), 0, 20)
     oled.show()
 
-setTime()
+set_time()
 oldTime = time.time()
 
 while True:
-    if checkUpdate(LASTUPDATE, UPDATEINTERVAL) == True:
-        setTime()
+    if check_update(LASTUPDATE, UPDATEINTERVAL): # '== True' no need
+        set_time()
 
     if time.time() != oldTime:
         oldTime = time.time()
         # printTime(time.localtime()[3], time.localtime()[4], time.localtime()[5])
-        printBinTime(time.localtime()[3], time.localtime()[4], time.localtime()[5])
+        print_bin_time(time.localtime()[3], time.localtime()[4], time.localtime()[5])


### PR DESCRIPTION
Mostly using 'pylint' checker - not 'micropython' friendly!

	modified:   ntptime.py

Hey Russ,
picked out as much stuff as I could find with pylint and what I know,
pylint complains loads about the variable names at the global level but ignore those for now.
Highlighted some 'magic numbers', best to pre-assign (most) of those (though this script is short, so is obvious)

The not-required 'else:' bits - took me some time to 'get it' when I first came across this, but the logic is there.

Also the 'if smthg == True:' bit - one of those python(ic) things not needing the '== True:' bit
to mean if it is in existance or a valid thing - I think this is a bit implicit, therefore hmm, pythonic? in any case checker says, don't use it or use ' is True:'

Also, a pain-in-the-ass checker doesn't like single letter arguments, h m s etc - again, I would prop ignore it and risk having my soul eternally boiled in lava by the python gods... : \

I haven't uploaded this to a board yet (will get round to that soon) but looking around at other repos, I'm seeing a few close variations, some using ntptime, some not - there is an RTC member in the machine module (curious) - some scripts also use sockets